### PR TITLE
P4c support

### DIFF
--- a/p4utils/utils/utils.py
+++ b/p4utils/utils/utils.py
@@ -124,16 +124,6 @@ def compile_p4_to_bmv2(config):
     """
     compiler_args = []
 
-    #read p4 version to be used
-    language = config.get("language", None)
-    if language == 'p4-14':
-        compiler_args.append('--p4v 14')
-    elif language == 'p4-16':
-        compiler_args.append('--p4v 16')
-    else:
-        log_error('Unknown language:', language)
-        sys.exit(1)
-
     #read compiler to use
     compiler = config.get("compiler", None)
     if not compiler:
@@ -144,7 +134,10 @@ def compile_p4_to_bmv2(config):
     if program_file:
         output_file = program_file.replace(".p4", "") + '.json'
         compiler_args.append('"%s"' % program_file)
-        compiler_args.append('-o "%s"' % output_file)
+        if compiler != 'p4c':
+            # The p4c compiler accepts only a directory for output files
+            # with the -o option, the output file name is set automatically
+            compiler_args.append('-o "%s"' % output_file)
     else:
         log_error("Unknown P4 file %s" % program_file)
         sys.exit(1)

--- a/p4utils/utils/utils.py
+++ b/p4utils/utils/utils.py
@@ -133,11 +133,16 @@ def compile_p4_to_bmv2(config):
     program_file = config.get("program", None)
     if program_file:
         output_file = program_file.replace(".p4", "") + '.json'
-        compiler_args.append('"%s"' % program_file)
-        if compiler != 'p4c':
+        if compiler.startswith('p4c'):
             # The p4c compiler accepts only a directory for output files
-            # with the -o option, the output file name is set automatically
-            compiler_args.append('-o "%s"' % output_file)
+            # Instead of a file name since it creates not only the .json,
+            # but also auxiliary files
+            output = os.path.dirname(os.path.realpath(output_file))
+        else:
+            output = output_file
+
+        compiler_args.append('"%s"' % program_file)
+        compiler_args.append('-o "%s"' % output)
     else:
         log_error("Unknown P4 file %s" % program_file)
         sys.exit(1)

--- a/p4utils/utils/utils.py
+++ b/p4utils/utils/utils.py
@@ -130,6 +130,11 @@ def compile_p4_to_bmv2(config):
         log_error("Compiler was not set")
         sys.exit(1)
 
+    # read compiler options (optional)
+    options = config.get("options", None)
+    if options:
+        compiler_args.append(options)
+
     program_file = config.get("program", None)
     if program_file:
         output_file = program_file.replace(".p4", "") + '.json'


### PR DESCRIPTION
Currently, the [p4c reference compiler](https://github.com/p4lang/p4c)
could be used, since its command line options differ from the *p4c-bm2-ss*
compiler in a few ways:

- the language switch is for `p4c` looks like: `--std p4-16` instead of
  `-p4v 16`
- the `-o` option does not specify an output file, but a path to a directory
  where the output files might be places

Being able to use the `p4c` compiler is useful, since it does not cause the
recent "includes" problems (e.g. core.p4 missing)[1]

The CLI differences conflicted with the config parsing, which I have modified
as follows:

- no `language` key in the config anymore, since any compiler might use a
  different command line option for this.
  The functionality is not lost, though, is is still possible
  to specify the language in the `compiler` field, e.g.:

  ```json
  "compiler": "p4c --std p4-14"
  ```

- Use file directory only for the  `-o` option when using the `p4c` compiler.
  I have added this exception because I think this behaviour is a bit unusual.
  All other compilers I know use the `-o` option to specify an output file.

[1]: p4lang/p4c#1179