### PR TITLE
Add a return value to meter_get_rates.

### DIFF
--- a/p4utils/utils/runtime_API.py
+++ b/p4utils/utils/runtime_API.py
@@ -1597,9 +1597,15 @@ class RuntimeAPI(object):
         if len(rates) != meter.rate_count:
             print "WARNING: expected", meter.rate_count, "rates",
             print "but only received", len(rates)
+
+        values = []
         for idx, rate in enumerate(rates):
             print "{}: info rate = {}, burst size = {}".format(
                 idx, rate.units_per_micros, rate.burst_size)
+            values.append(rate.units_per_micros)
+            values.append(rate.burst_size)
+
+        return values
 
     @handle_bad_input
     def counter_read(self, counter_name, index):


### PR DESCRIPTION
meter_get_rates was only printing the rates and burst rates. We changed this to have a return value that can be used in the controller.