### PR TITLE
Replace git:// with https://

### DIFF
--- a/install-tools/install-p4-dev.sh
+++ b/install-tools/install-p4-dev.sh
@@ -513,7 +513,7 @@ function do_ptf {
 function do_mininet {
     # Clone source
     cd $HOME
-    git clone git://github.com/mininet/mininet mininet
+    git clone https://github.com/mininet/mininet mininet
     cd mininet
 
     # Build mininet


### PR DESCRIPTION
Error - The unauthenticated git protocol on port 9418 is no longer supported.
Solution - Replace git:// with https://
Explanation - https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git