### PR TITLE
The timeout duration for starting/stopping a switch may be a little bit short.

### DIFF
--- a/p4utils/mininetlib/node.py
+++ b/p4utils/mininetlib/node.py
@@ -30,8 +30,8 @@ from p4utils.utils.helper import *
 from p4utils.mininetlib.log import debug, info, output, warning, error, critical
 
 
-SWITCH_START_TIMEOUT = 10
-SWITCH_STOP_TIMEOUT = 10
+SWITCH_START_TIMEOUT = 30
+SWITCH_STOP_TIMEOUT = 30
 
 
 class P4Host(Host):


### PR DESCRIPTION
  I've encountered a problem when creating/stopping a topology containing 144 hosts and 13 switches with p4utils. There is a high probability that the program will raise a ChildProcessError which saying "P4 swich xx did not start/stop correctly.". I digged into the source code and found that the error was from the if sentence: "if not wait_condition(self.switch_status, True, timeout=SWITCH_START_TIMEOUT".
  To my understanding, the time limit for a child process to create or stop a P4 switch may not be long enough when creating a larger topology, so I changed the global variables "SWITCH_START_TIMEOUT" and "SWITCH_STOP_TIMEOUT" from 10 to 60. This solution worked and the problem didn't occured again after I changed the code.
  I'm not certained whether my understanding is correct, so I make this pull request. It will appreciate it if you can give me a replym, and I hope this adjustment to the code can help others meeting the same problem