### PR TITLE
Fix ethtool -k (query) used instead of -K (set)

### DIFF
--- a/p4utils/mininetlib/net.py
+++ b/p4utils/mininetlib/net.py
@@ -141,7 +141,7 @@ class P4Mininet(Mininet):
 
         #remove Ipv6 for all the interfaces
         for link in self.links:
-            cmd1 = "/sbin/ethtool -k {0} rx off tx off sg off"
+            cmd1 = "/sbin/ethtool -K {0} rx off tx off sg off"
             cmd2 = "sysctl net.ipv6.conf.{0}.disable_ipv6=1"
             cmd3 = "ip link set {} mtu {}"
 


### PR DESCRIPTION
The lowercase -k flag is used to query options. In this case we want to modify options, therefore uppercase -K must be used instead.