### PR TITLE
Allow non-blocking reading of digests (with timeout=0)

### DIFF
--- a/p4utils/utils/p4runtime_API/p4runtime.py
+++ b/p4utils/utils/p4runtime_API/p4runtime.py
@@ -211,20 +211,16 @@ class P4RuntimeClient:
             packet (protobuf message)
         """
         start = time.time()
+        remaining = timeout
         try:
             while True:
-                if timeout is not None:
-                    remaining = timeout - (time.time() - start)
-                    if remaining < 0:
-                        break
-                else:
-                    remaining = None
+                if remaining is not None and remaining < 0:
+                    break
                 msg = self.stream_in_q.get(timeout=remaining)
-                if msg is None:
-                    return None
-                if not msg.HasField(type_):
-                    continue
-                return msg
+                if msg is None or msg.HasField(type_):
+                    return msg
+                if remaining is not None:
+                    remaining = timeout - (time.time() - start)
         except queue.Empty:  # timeout expired
             pass
         return None


### PR DESCRIPTION
This change lets us call `SimpleSwitchP4RuntimeAPI.get_digest_list` with very low timeout values, e.g. `timeout=0`. Currently, a low timeout results in no digest being read (because the timeout is instantly over). With this fix, the timeout is not taken into account if no waiting is necessary because a digest is already available (because a digest has already been received previously).

Motivation: I want to be able to read a digest from one of the switches in the network. If the digest reading is a blocking operation, then it takes a considerable amount of time to iterate over all switches. This simple patch allows users to use digest reading as a non blocking operation, without having to use sockets or `select.select` directly.